### PR TITLE
build.sh: use light return code comparators.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,8 @@ TYPE="_$3"
 export FINAL_ZIP="$KNAME"-"$DEVICE""$TYPE""$VER"_"$DATE".zip
 
 # Sanity check to avoid using erroneous binaries
-if [ -e  out/arch/$ARCH/boot/*Image* ] ; then
+if [ -e  out/arch/$ARCH/boot/*Image* ]
+then
 	rm -r out
 	rm $AK2DIR/*.dtb
 	rm $AK2DIR/*Image*
@@ -35,7 +36,8 @@ if [ -e  out/arch/$ARCH/boot/*Image* ] ; then
 	touch $AK2DIR/modules/system/lib/modules/placeholder
 fi
 
-if [ "$1" == 'auto' ] ; then
+if [ "$1" == 'auto' ]
+then
 	t=$(nproc --all)
 else
 	t=$1
@@ -45,30 +47,15 @@ printf "\nTHREADS: $t\nVERSION: $2\nRELEASE: $3\nGCC VERSION: $GCCV\n\n"
 echo "==> Adapted build script, courtest of @facuarmo"
 echo "==> Making kernel binary..."
 make O=out perry_defconfig
-make O=out -j$t zImage |& tee fail.log
-if [ ${PIPESTATUS[0]} -ne 0 ] ; then
-	echo "!!! Kernel compilation failed, can't continue !!!"
-	gdrive upload --delete fail.log
-	exit 2
-fi
+make O=out -j$t zImage |& tee fail.log || echo "!!! Kernel compilation failed, can't continue !!!" ; gdrive upload --delete fail.log ; exit 2
 echo "=> Making modules..."
-make O=out -j$t modules |& tee -a fail.log
-if [ ${PIPESTATUS[0]} -ne 0 ] ; then
-	echo "Module compilation failed, can't continue."
-	gdrive upload --delete fail.log
-	exit 1
-fi
+make O=out -j$t modules |& tee -a fail.log || echo "Module compilation failed, can't continue." ; gdrive upload --delete fail.log ; exit 1
 rm -rf out/modinstall
 mkdir out/modinstall
-make O=out -j$t modules_install INSTALL_MOD_PATH=modinstall INSTALL_MOD_STRIP=1 |& tee -a fail.log
-if [ ${PIPESTATUS[0]} -ne 0 ] ; then
-	echo "Module installation failed, can't continue."
-	gdrive upload --delete fail.log
-	exit 1
-fi
-
+make O=out -j$t modules_install INSTALL_MOD_PATH=modinstall INSTALL_MOD_STRIP=1 |& tee -a fail.log || echo "Module installation failed, can't continue." ; gdrive upload --delete fail.log ; exit 1
 # One more sanity check
-if [ -e $AK2DIR/*Image* ] ; then
+if [ -e $AK2DIR/*Image* ]
+then
 	rm $AK2DIR/*.zip
 	rm $AK2DIR/*Image*
 	rm $AK2DIR/*.dtb
@@ -92,7 +79,8 @@ cd $AK2DIR
 
 zip -r9 $FINAL_ZIP * -x .git README.md *placeholder > /dev/null
 
-if [ -e $FINAL_ZIP ] ; then
+if [ -e $FINAL_ZIP ]
+then
 	echo "==> Flashable zip created"
 	echo "==> Uploading $FINAL_ZIP to Google Drive"
 	gdrive upload --delete $AK2DIR/$FINAL_ZIP


### PR DESCRIPTION
Replace any return codes comparation for a simple comparator, instead of doing two or three checks, we stick to only one. All subsequent actions will pass regardless of the previous output (error messages).

Make the code more "bash-looking".