### PR TITLE
build.sh: remove tee, improve performance.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,28 +45,12 @@ printf "\nTHREADS: $t\nVERSION: $2\nRELEASE: $3\nGCC VERSION: $GCCV\n\n"
 echo "==> Adapted build script, courtest of @facuarmo"
 echo "==> Making kernel binary..."
 make O=out perry_defconfig
-make O=out -j$t zImage |& tee fail.log
-if [ ${PIPESTATUS[0]} -ne 0 ] ; then
-	echo "!!! Kernel compilation failed, can't continue !!!"
-	gdrive upload --delete fail.log
-	exit 2
-fi
+make O=out -j$t zImage 2> fail.log || echo "!!! Kernel compilation failed, can't continue !!!" ; gdrive upload --delete fail.log ; exit 2
 echo "=> Making modules..."
-make O=out -j$t modules |& tee -a fail.log
-if [ ${PIPESTATUS[0]} -ne 0 ] ; then
-	echo "Module compilation failed, can't continue."
-	gdrive upload --delete fail.log
-	exit 1
-fi
+make O=out -j$t modules 2>> fail.log || echo "Module compilation failed, can't continue." ; gdrive upload --delete fail.log ; exit 1
 rm -rf out/modinstall
 mkdir out/modinstall
-make O=out -j$t modules_install INSTALL_MOD_PATH=modinstall INSTALL_MOD_STRIP=1 |& tee -a fail.log
-if [ ${PIPESTATUS[0]} -ne 0 ] ; then
-	echo "Module installation failed, can't continue."
-	gdrive upload --delete fail.log
-	exit 1
-fi
-
+make O=out -j$t modules_install INSTALL_MOD_PATH=modinstall INSTALL_MOD_STRIP=1 2>> fail.log || echo "Module installation failed, can't continue." ; gdrive upload --delete fail.log ; exit 1
 # One more sanity check
 if [ -e $AK2DIR/*Image* ] ; then
 	rm $AK2DIR/*Image*


### PR DESCRIPTION
Remove tee and use output pipes instead.
Remove some "if/else" blocks and use light ways to compare instead.